### PR TITLE
Fix typo in features

### DIFF
--- a/src/components/HomepageFeatures.js
+++ b/src/components/HomepageFeatures.js
@@ -9,7 +9,7 @@ const FeatureList = [
     description: (
       <>
         The syntax of Unv language is inspired by Python. So It's nearly similar to English.
-        instead of too many brackets or depending on whitespace.
+        Instead of too many brackets, it depends on whitespaces.
       </>
     ),
   },

--- a/src/components/HomepageFeatures.js
+++ b/src/components/HomepageFeatures.js
@@ -9,7 +9,7 @@ const FeatureList = [
     description: (
       <>
         The syntax of Unv language is inspired by Python. So It's nearly similar to English.
-        instead of too many brackets ot depends on whitespace.
+        instead of too many brackets or depending on brackets.
       </>
     ),
   },

--- a/src/components/HomepageFeatures.js
+++ b/src/components/HomepageFeatures.js
@@ -9,7 +9,7 @@ const FeatureList = [
     description: (
       <>
         The syntax of Unv language is inspired by Python. So It's nearly similar to English.
-        instead of too many brackets or depending on brackets.
+        instead of too many brackets or depending on whitespace.
       </>
     ),
   },


### PR DESCRIPTION
The syntax of Unv language is inspired by Python. So It's nearly similar to English. instead of too many brackets ot depends on whitespace. 
**changed to :**         
changed The syntax of Unv language is inspired by Python. So It's nearly similar to English. instead of too many brackets or depending on whitespace. 